### PR TITLE
[TASK] Publish to TER via GitHub action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "**"
+
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+      - name: "Publish new version to TER"
+        uses: tomasnorre/typo3-upload-ter@v2
+        with:
+          api-token: ${{ secrets.TYPO3_API_TOKEN }}

--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,12 @@
 		"psr-4": {
 			"TYPO3\\CMS\\Func\\": "Classes/"
 		}
+	},
+	"scripts": {
+		"prepare-release": [
+			"rm -rf .github/",
+			"rm .editorconfig",
+			"rm .gitignore"
+		]
 	}
 }


### PR DESCRIPTION
Automate publishing of coming releases to TER alongside Packagist with this GitHub action.

Manual todos: 
(1) Add `TYPO3_API_TOKEN` setting in GitHub secrets of this repository. 
(2) Add release commit with body `[RELEASE] v9.0.3`, tag commit with `v9.0.3` and watch the GitHub workflow deploying to TER automatically.

Relates: #7 